### PR TITLE
bundle dev dependency jest-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-prettier": "^3.0.1",
     "jest": "^24.7.1",
+    "jest-cli": "^24.8.0",
     "prettier": "^1.16.4"
   },
   "homepage": "https://github.com/constverum/stylelint-config-rational-order"


### PR DESCRIPTION
Now tests can be run with just `npm i; npm test`, no need to additionally `npm i -D jest-cli`

✌️ 