### PR TITLE
Added "row-gap" and "column-gap" to the boxmodel group

### DIFF
--- a/groups/boxModel.js
+++ b/groups/boxModel.js
@@ -28,6 +28,8 @@ const partOne = [
   'grid-template-rows',
   'grid-template-columns',
   'gap',
+  'row-gap',
+  'column-gap',
   'align-content',
   'align-items',
   'align-self',


### PR DESCRIPTION
The properties "grid-column-gap" and "grid-row-gap" have been deprecated in favor for the "column-gap" and "row-gap" properties. I would like to see these added to the boxmodel group