### PR TITLE
Add inset (and sub-properties) to positioning

### DIFF
--- a/groups/positioning.js
+++ b/groups/positioning.js
@@ -1,1 +1,15 @@
-module.exports = ['position', 'top', 'right', 'bottom', 'left', 'z-index'];
+module.exports = [
+    'position',
+    'inset',
+    'inset-block',
+    'inset-block-start',
+    'inset-block-end',
+    'inset-inline',
+    'inset-inline-start',
+    'inset-inline-end',
+    'top',
+    'right',
+    'bottom',
+    'left',
+    'z-index'
+];


### PR DESCRIPTION
The positioning group was lacking the following CSS properties:
* [inset](https://developer.mozilla.org/en-US/docs/Web/CSS/inset)
* [inset-block](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block)
* [inset-block-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start)
* [inset-block-end](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end)
* [inset-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline)
* [inset-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start)
* [inset-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end)

These properties have been added right under `position` and above `top`.